### PR TITLE
Fix descriptor data length in dump_builder_json output

### DIFF
--- a/fwpkg_unpack.py
+++ b/fwpkg_unpack.py
@@ -801,10 +801,14 @@ class PLDMUnpack:
             desc_list = []
             for descriptors in device_records["RecordDescriptors"]:
                 if descriptors.get("InitialDescriptorType"):
+                    data = descriptors.get("InitialDescriptorData")
+                    data_len = len(data)
                     desc_data = {
                         "DescriptorType": descriptors.get("InitialDescriptorType"),
-                        "DescriptorData": hex(int.from_bytes(descriptors.get(
-                            "InitialDescriptorData"), byteorder='big', signed=False))[2:],
+                        "DescriptorData": int.from_bytes(
+                            data,
+                            byteorder='big',
+                            signed=False).to_bytes(data_len, 'big').hex()
                     }
                 elif descriptors.get("AdditionalDescriptorType") == 65535:
                     desc_data = {
@@ -815,12 +819,14 @@ class PLDMUnpack:
                             "VendorDefinedDescriptorData")
                     }
                 else:
+                    data = descriptors.get("AdditionalDescriptorIdentifierData")
+                    data_len = len(data)
                     desc_data = {
                         "DescriptorType": descriptors.get("AdditionalDescriptorType"),
-                        "DescriptorData": hex(int.from_bytes(descriptors.get(
-                            "AdditionalDescriptorIdentifierData"),
+                        "DescriptorData": int.from_bytes(
+                            data,
                             byteorder='big',
-                            signed=False))[2:],
+                            signed=False).to_bytes(data_len, 'big').hex()
                     }
                 desc_list.append(desc_data)
             fw_id_rec["Descriptors"] = desc_list


### PR DESCRIPTION
Prefixed Descriptors with 0's to match expected data length

```
$ python3 fwpkg_unpack.py --dump_builder_json ~/packages/nvfw_GB200-P4972_0004_240828.1.0_custom_prod-signed.fwpkg
{
    "PackageHeaderInformation": {
        "PackageHeaderIdentifier": "f018878ccb7d49439800a02f059aca02",
        "PackageHeaderFormatVersion": 1,
        "PackageReleaseDateTime": "28/08/2024 03:46:27",
        "PackageVersionString": "GB200-P4972_0004_240828.1.0_custom"
    },
    "FirmwareDeviceIdentificationArea": [
        {
            "DeviceUpdateOptionFlags": [],
            "ComponentImageSetVersionString": "ERoT,BMC:SKU_178:",
            "ApplicableComponents": [
                0,
                1
            ],
            "Descriptors": [
                {
                    "DescriptorType": 1,
                    "DescriptorData": "47160000"
                },
                {
                    "DescriptorType": 2,
                    "DescriptorData": "162023c93ec5411595f448701d49d675"
                },
                {
                    "DescriptorType": 65535,
                    "VendorDefinedDescriptorTitleString": "GLACIERDSD",
                    "VendorDefinedDescriptorData": "10"
                },
                {
                    "DescriptorType": 0,
                    "DescriptorData": "031a"
                },
                {
                    "DescriptorType": 256,
                    "DescriptorData": "0026"
                },
                {
                    "DescriptorType": 257,
                    "DescriptorData": "de10"
                },
                {
                    "DescriptorType": 258,
                    "DescriptorData": "4316"
                },
                {
                    "DescriptorType": 65535,
                    "VendorDefinedDescriptorTitleString": "APSKU",
                    "VendorDefinedDescriptorData": "b2000010"
                },
                {
                    "DescriptorType": 65535,
                    "VendorDefinedDescriptorTitleString": "ECSKU",
                    "VendorDefinedDescriptorData": "4d35368b"
                }
            ]
        }
    ],
    "ComponentImageInformationArea": [
        {
            "ComponentClassification": 10,
            "ComponentIdentifier": 65280,
            "ComponentOptions": [
                1
            ],
            "RequestedComponentActivationMethod": [],
            "ComponentVersionString": "01.03.0183.0000_n04",
            "ComponentComparisonStamp": "0x0103b700"
        },
        {
            "ComponentClassification": 10,
            "ComponentIdentifier": 16,
            "ComponentOptions": [
                1
            ],
            "RequestedComponentActivationMethod": [],
            "ComponentVersionString": "GB200Nvl-24.08-9",
            "ComponentComparisonStamp": "0x00240809"
        }
    ]
}
```